### PR TITLE
Fix wrong return statement

### DIFF
--- a/SubstrateCS/Source/TileEntities/TileEntityBeacon.cs
+++ b/SubstrateCS/Source/TileEntities/TileEntityBeacon.cs
@@ -69,7 +69,7 @@ namespace Substrate.TileEntities
 
         public override TileEntity Copy ()
         {
-            return new TileEntityMusic(this);
+            return new TileEntityBeacon(this);
         }
 
         #endregion


### PR DESCRIPTION
Fixes TileEntityBeacon.Copy() returning a TileEntityMusic
