### PR TITLE
Add support for accessing Biome information stored in an Anvil chunk

### DIFF
--- a/SubstrateCS/Source/AlphaChunk.cs
+++ b/SubstrateCS/Source/AlphaChunk.cs
@@ -82,6 +82,11 @@ namespace Substrate
             get { return _blockManager; }
         }
 
+        public AnvilBiomeCollection Biomes
+        {
+            get { return null; }
+        }
+
         /// <summary>
         /// Gets the collection of all entities stored in the chunk.
         /// </summary>

--- a/SubstrateCS/Source/AnvilBiomeCollection.cs
+++ b/SubstrateCS/Source/AnvilBiomeCollection.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using Substrate.Core;
+using Substrate.Nbt;
+
+namespace Substrate
+{
+    public class AnvilBiomeCollection
+    {
+        public const int OCEAN = 0;
+        public const int PLAINS = 1;
+        public const int DESERT = 2;
+        public const int EXTREME_HILLS = 3;
+        public const int FOREST = 4;
+        public const int TAIGA = 5;
+        public const int SWAMPLAND = 6;
+        public const int RIVER = 7;
+        public const int HELL = 8;
+        public const int SKY = 9;
+        public const int FROZEN_OCEAN = 10;
+        public const int FROZEN_RIVER = 11;
+        public const int ICE_PLAINS = 12;
+        public const int ICE_MOUNTAINS = 13;
+        public const int MUSHROOM_ISLAND = 14;
+        public const int MUSHROOM_ISLAND_SHORE = 15;
+        public const int BEACH = 16;
+        public const int DESERT_HILLS = 17;
+        public const int FOREST_HILLS = 18;
+        public const int TAIGA_HILLS = 19;
+        public const int EXTREME_HILLS_EDGE = 20;
+        public const int JUNGLE = 21;
+        public const int JUNGLE_HILLS = 22;
+
+        private readonly int _xdim;
+        private readonly int _zdim;
+
+        private IDataArray2 _biomeMap;
+
+        public AnvilBiomeCollection(IDataArray2 biomeMap)
+        {
+            _biomeMap = biomeMap;
+
+            _xdim = _biomeMap.XDim;
+            _zdim = _biomeMap.ZDim;
+        }
+
+        public int GetBiome(int x, int z)
+        {
+            return _biomeMap[x, z];
+        }
+
+        public void SetBiome(int x, int z, int newBiome)
+        {
+            _biomeMap[x, z] = newBiome;
+        }
+
+    }
+}

--- a/SubstrateCS/Source/AnvilChunk.cs
+++ b/SubstrateCS/Source/AnvilChunk.cs
@@ -58,6 +58,7 @@ namespace Substrate
 
         private AlphaBlockCollection _blockManager;
         private EntityCollection _entityManager;
+        private AnvilBiomeCollection _biomeManager;
 
 
         private AnvilChunk ()
@@ -78,6 +79,11 @@ namespace Substrate
         public AlphaBlockCollection Blocks
         {
             get { return _blockManager; }
+        }
+
+        public AnvilBiomeCollection Biomes
+        {
+            get { return _biomeManager; }
         }
 
         public EntityCollection Entities
@@ -291,6 +297,7 @@ namespace Substrate
 
             _blockManager = new AlphaBlockCollection(_blocks, _data, _blockLight, _skyLight, _heightMap, _tileEntities, _tileTicks);
             _entityManager = new EntityCollection(_entities);
+            _biomeManager = new AnvilBiomeCollection(_biomes);
 
             return this;
         }

--- a/SubstrateCS/Source/ChunkRef.cs
+++ b/SubstrateCS/Source/ChunkRef.cs
@@ -17,6 +17,7 @@ namespace Substrate
         private IChunk _chunk;
 
         private AlphaBlockCollection _blocks;
+        private AnvilBiomeCollection _biomes;
         private EntityCollection _entities;
 
         private int _cx;
@@ -61,12 +62,28 @@ namespace Substrate
         /// </summary>
         public AlphaBlockCollection Blocks
         {
-            get 
+            get
             {
-                if (_blocks == null) {
+                if (_blocks == null)
+                {
                     GetChunk();
                 }
                 return _blocks;
+            }
+        }
+
+        /// <summary>
+        /// Gets the collection of all blocks and their data stored in the chunk.
+        /// </summary>
+        public AnvilBiomeCollection Biomes
+        {
+            get
+            {
+                if (_biomes == null)
+                {
+                    GetChunk();
+                }
+                return _biomes;
             }
         }
 
@@ -268,8 +285,10 @@ namespace Substrate
             if (_chunk == null) {
                 _chunk = _container.GetChunk(_cx, _cz);
 
-                if (_chunk != null) {
+                if (_chunk != null)
+                {
                     _blocks = _chunk.Blocks;
+                    _biomes = _chunk.Biomes;
                     _entities = _chunk.Entities;
 
                     // Set callback functions in the underlying block collection

--- a/SubstrateCS/Source/Core/ChunkInterface.cs
+++ b/SubstrateCS/Source/Core/ChunkInterface.cs
@@ -31,6 +31,11 @@ namespace Substrate.Core
         EntityCollection Entities { get; }
 
         /// <summary>
+        /// Gets access to an <see cref="AnvilBiomeCollection"/> representing all biome data of a chunk.
+        /// </summary>
+        AnvilBiomeCollection Biomes { get; }
+
+        /// <summary>
         /// Gets or sets the flag indicating that the terrain generator has created terrain features.
         /// </summary>
         /// <remarks>Terrain features include ores, water and lava sources, dungeons, trees, flowers, etc.</remarks>

--- a/SubstrateCS/Substrate (NET2).csproj
+++ b/SubstrateCS/Substrate (NET2).csproj
@@ -60,6 +60,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Source\AlphaWorld.cs" />
+    <Compile Include="Source\AnvilBiomeCollection.cs" />
     <Compile Include="Source\AnvilChunk.cs" />
     <Compile Include="Source\AnvilRegion.cs" />
     <Compile Include="Source\AnvilRegionManager.cs" />

--- a/SubstrateCS/Substrate (NET4).csproj
+++ b/SubstrateCS/Substrate (NET4).csproj
@@ -61,6 +61,7 @@
   <ItemGroup>
     <Compile Include="Source\AlphaChunk.cs" />
     <Compile Include="Source\AlphaWorld.cs" />
+    <Compile Include="Source\AnvilBiomeCollection.cs" />
     <Compile Include="Source\AnvilChunk.cs" />
     <Compile Include="Source\AnvilRegion.cs" />
     <Compile Include="Source\AnvilRegionManager.cs" />


### PR DESCRIPTION
Added support for accessing and modifying biomes.  Changed IChunk to add support for the AnvilBiomeCollection class, which is just a wrapper around the ZXByteArray that stores biome info.  AlphaChunk.cs just stubs the getter for this to return NULL, since alpha biomes are mathmatically generated at run-time, and cannot be edited.
