### PR TITLE
Chunk enumerator no longer crashes when attempting to load empty dimensions

### DIFF
--- a/SubstrateCS/Source/RegionChunkManager.cs
+++ b/SubstrateCS/Source/RegionChunkManager.cs
@@ -377,12 +377,15 @@ namespace Substrate
             {
                 _cm = cm;
                 _enum = _cm.RegionManager.GetEnumerator();
-                _enum.MoveNext();
-                _region = _enum.Current;
+                if (_enum.MoveNext())
+                    _region = _enum.Current;
             }
 
             public virtual bool MoveNext ()
             {
+                if (_region == null)
+                    return false;
+
                 if (_enum == null) {
                     return MoveNextInRegion();
                 }


### PR DESCRIPTION
If a dimension's folder is created (DIM1, DIM-1, DIM_MYST6, etc) but contains no files, attempting to iterate through chunks will throw an exception.  A pair of changes to RegionChunkManager.cs fix this problem.
Signed-off-by: Sukasa nick.m@shaw.ca
