### PR TITLE
Add support for text-based block/item IDs

### DIFF
--- a/SubstrateCS/Source/BlockInfo.cs
+++ b/SubstrateCS/Source/BlockInfo.cs
@@ -310,6 +310,7 @@ namespace Substrate
 
         private int _id = 0;
         private string _name = "";
+        private string _internal_name = "";
         private int _tick = 0;
         private int _opacity = MAX_OPACITY;
         private int _luminance = MIN_LUMINANCE;
@@ -332,6 +333,19 @@ namespace Substrate
         {
             get { return _blockTableCache; }
         }
+
+        public static BlockInfo GetBlockInfoByInternalName(string internalName)
+        {
+          foreach (BlockInfo info in _blockTable)
+          {
+            if (info._internal_name == internalName)
+            {
+              return info;
+            }
+          }
+          return null;
+        }
+
 
         /// <summary>
         /// Gets the lookup table for id-to-opacity values.
@@ -434,6 +448,8 @@ namespace Substrate
             _id = id;
             _name = "Unknown Block";
             _blockTable[_id] = this;
+            _internal_name = "minecraft:" + _name.ToLower().Replace(' ', '_');
+            _name += string.Format(" ({0})", id);
         }
 
         /// <summary>
@@ -448,6 +464,13 @@ namespace Substrate
             _name = name;
             _blockTable[_id] = this;
             _registered = true;
+            _internal_name = "minecraft:" + name.ToLower().Replace(' ', '_');
+        }
+
+        public BlockInfo SetInternalName(string name)
+        {
+          _internal_name = "minecraft:" + name;
+          return this;
         }
 
         /// <summary>
@@ -749,7 +772,7 @@ namespace Substrate
             Grass = new BlockInfo(2, "Grass").SetTick(10);
             Dirt = new BlockInfo(3, "Dirt");
             Cobblestone = new BlockInfo(4, "Cobblestone");
-            WoodPlank = new BlockInfo(5, "Wooden Plank");
+            WoodPlank = new BlockInfo(5, "Wooden Plank").SetInternalName("planks");
             Sapling = new BlockInfo(6, "Sapling").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10);
             Bedrock = new BlockInfo(7, "Bedrock");
             Water = new BlockInfo(8, "Water").SetOpacity(3).SetState(BlockState.FLUID).SetTick(5);
@@ -761,43 +784,43 @@ namespace Substrate
             GoldOre = new BlockInfo(14, "Gold Ore");
             IronOre = new BlockInfo(15, "Iron Ore");
             CoalOre = new BlockInfo(16, "Coal Ore");
-            Wood = new BlockInfo(17, "Wood");
+            Wood = new BlockInfo(17, "Wood").SetInternalName("log");
             Leaves = new BlockInfo(18, "Leaves").SetOpacity(1).SetTick(10);
             Sponge = new BlockInfo(19, "Sponge");
             Glass = new BlockInfo(20, "Glass").SetOpacity(0);
-            LapisOre = new BlockInfo(21, "Lapis Lazuli Ore");
-            LapisBlock = new BlockInfo(22, "Lapis Lazuli Block");
+            LapisOre = new BlockInfo(21, "Lapis Lazuli Ore").SetInternalName("lapis_ore");
+            LapisBlock = new BlockInfo(22, "Lapis Lazuli Block").SetInternalName("lapis_block");
             Dispenser = (BlockInfoEx)new BlockInfoEx(23, "Dispenser").SetTick(4);
             Sandstone = new BlockInfo(24, "Sandstone");
-            NoteBlock = new BlockInfoEx(25, "Note Block");
+            NoteBlock = (BlockInfoEx)new BlockInfoEx(25, "Note Block").SetInternalName("noteblock");
             Bed = new BlockInfo(26, "Bed").SetOpacity(0);
-            PoweredRail = new BlockInfo(27, "Powered Rail").SetOpacity(0).SetState(BlockState.NONSOLID);
+            PoweredRail = new BlockInfo(27, "Powered Rail").SetOpacity(0).SetState(BlockState.NONSOLID).SetInternalName("golden_rail");
             DetectorRail = new BlockInfo(28, "Detector Rail").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(20);
             StickyPiston = new BlockInfo(29, "Sticky Piston").SetOpacity(0);
-            Cobweb = new BlockInfo(30, "Cobweb").SetOpacity(0).SetState(BlockState.NONSOLID);
-            TallGrass = new BlockInfo(31, "Tall Grass").SetOpacity(0).SetState(BlockState.NONSOLID);
-            DeadShrub = new BlockInfo(32, "Dead Shrub").SetOpacity(0).SetState(BlockState.NONSOLID);
+            Cobweb = new BlockInfo(30, "Cobweb").SetOpacity(0).SetState(BlockState.NONSOLID).SetInternalName("web");
+            TallGrass = new BlockInfo(31, "Tall Grass").SetOpacity(0).SetState(BlockState.NONSOLID).SetInternalName("tallgrass");
+            DeadShrub = new BlockInfo(32, "Dead Shrub").SetOpacity(0).SetState(BlockState.NONSOLID).SetInternalName("deadbush");
             Piston = new BlockInfo(33, "Piston").SetOpacity(0);
             PistonHead = new BlockInfo(34, "Piston Head").SetOpacity(0);
             Wool = new BlockInfo(35, "Wool");
             PistonMoving = (BlockInfoEx)new BlockInfoEx(36, "Piston Moving").SetOpacity(0);
-            YellowFlower = new BlockInfo(37, "Yellow Flower").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10);
-            RedRose = new BlockInfo(38, "Red Rose").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10);
+            YellowFlower = new BlockInfo(37, "Yellow Flower").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10).SetInternalName("yellow_flower");
+            RedRose = new BlockInfo(38, "Red Rose").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10).SetInternalName("red_flower");
             BrownMushroom = new BlockInfo(39, "Brown Mushroom").SetOpacity(0).SetLuminance(1).SetState(BlockState.NONSOLID).SetTick(10);
             RedMushroom = new BlockInfo(40, "Red Mushroom").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10);
             GoldBlock = new BlockInfo(41, "Gold Block");
             IronBlock = new BlockInfo(42, "Iron Block");
-            DoubleStoneSlab = new BlockInfo(43, "Double Slab");
-            StoneSlab = new BlockInfo(44, "Slab").SetOpacity(0);
+            DoubleStoneSlab = new BlockInfo(43, "Double Slab").SetInternalName("double_stone_slab");
+            StoneSlab = new BlockInfo(44, "Slab").SetOpacity(0).SetInternalName("stone_slab");
             BrickBlock = new BlockInfo(45, "Brick Block");
             TNT = new BlockInfo(46, "TNT");
             Bookshelf = new BlockInfo(47, "Bookshelf");
-            MossStone = new BlockInfo(48, "Moss Stone");
+            MossStone = new BlockInfo(48, "Moss Stone").SetInternalName("mossy_cobblestone");
             Obsidian = new BlockInfo(49, "Obsidian");
             Torch = new BlockInfo(50, "Torch").SetOpacity(0).SetLuminance(MAX_LUMINANCE - 1).SetState(BlockState.NONSOLID).SetTick(10);
             Fire = new BlockInfo(51, "Fire").SetOpacity(0).SetLuminance(MAX_LUMINANCE).SetState(BlockState.NONSOLID).SetTick(40);
             MonsterSpawner = (BlockInfoEx)new BlockInfoEx(52, "Monster Spawner").SetOpacity(0);
-            WoodStairs = new BlockInfo(53, "Wooden Stairs").SetOpacity(0);
+            WoodStairs = new BlockInfo(53, "Wooden Stairs").SetOpacity(0).SetInternalName("oak_stairs");
             Chest = (BlockInfoEx)new BlockInfoEx(54, "Chest").SetOpacity(0);
             RedstoneWire = new BlockInfo(55, "Redstone Wire").SetOpacity(0).SetState(BlockState.NONSOLID);
             DiamondOre = new BlockInfo(56, "Diamond Ore");
@@ -810,8 +833,8 @@ namespace Substrate
             SignPost = (BlockInfoEx)new BlockInfoEx(63, "Sign Post").SetOpacity(0).SetState(BlockState.NONSOLID);
             WoodDoor = new BlockInfo(64, "Wooden Door").SetOpacity(0);
             Ladder = new BlockInfo(65, "Ladder").SetOpacity(0);
-            Rails = new BlockInfo(66, "Rails").SetOpacity(0).SetState(BlockState.NONSOLID);
-            CobbleStairs = new BlockInfo(67, "Cobblestone Stairs").SetOpacity(0);
+            Rails = new BlockInfo(66, "Rails").SetOpacity(0).SetState(BlockState.NONSOLID).SetInternalName("rail");
+            CobbleStairs = new BlockInfo(67, "Cobblestone Stairs").SetOpacity(0).SetInternalName("stone_stairs");
             WallSign = (BlockInfoEx)new BlockInfoEx(68, "Wall Sign").SetOpacity(0).SetState(BlockState.NONSOLID);
             Lever = new BlockInfo(69, "Lever").SetOpacity(0).SetState(BlockState.NONSOLID);
             StonePlate = new BlockInfo(70, "Stone Pressure Plate").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(20);
@@ -819,59 +842,59 @@ namespace Substrate
             WoodPlate = new BlockInfo(72, "Wooden Pressure Plate").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(20);
             RedstoneOre = new BlockInfo(73, "Redstone Ore").SetTick(30);
             GlowRedstoneOre = new BlockInfo(74, "Glowing Redstone Ore").SetLuminance(9).SetTick(30);
-            RedstoneTorch = new BlockInfo(75, "Redstone Torch (Off)").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(2);
-            RedstoneTorchOn = new BlockInfo(76, "Redstone Torch (On)").SetOpacity(0).SetLuminance(7).SetState(BlockState.NONSOLID).SetTick(2);
+            RedstoneTorch = new BlockInfo(75, "Redstone Torch (Off)").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(2).SetInternalName("unlit_redstone_torch");
+            RedstoneTorchOn = new BlockInfo(76, "Redstone Torch (On)").SetOpacity(0).SetLuminance(7).SetState(BlockState.NONSOLID).SetTick(2).SetInternalName("redstone_torch");
             StoneButton = new BlockInfo(77, "Stone Button").SetOpacity(0).SetState(BlockState.NONSOLID);
-            Snow = new BlockInfo(78, "Snow").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10);
+            Snow = new BlockInfo(78, "Snow").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10).SetInternalName("snow_layer");
             Ice = new BlockInfo(79, "Ice").SetOpacity(3).SetTick(10);
             SnowBlock = new BlockInfo(80, "Snow Block").SetTick(10);
             Cactus = new BlockInfo(81, "Cactus").SetOpacity(0).SetTick(10);
             ClayBlock = new BlockInfo(82, "Clay Block");
-            SugarCane = new BlockInfo(83, "Sugar Cane").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10);
+            SugarCane = new BlockInfo(83, "Sugar Cane").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10).SetInternalName("reeds");
             Jukebox = new BlockInfo(84, "Jukebox");
             Fence = new BlockInfo(85, "Fence").SetOpacity(0);
             Pumpkin = new BlockInfo(86, "Pumpkin");
             Netherrack = new BlockInfo(87, "Netherrack");
             SoulSand = new BlockInfo(88, "Soul Sand");
-            Glowstone = new BlockInfo(89, "Glowstone Block").SetLuminance(MAX_LUMINANCE);
+            Glowstone = new BlockInfo(89, "Glowstone Block").SetLuminance(MAX_LUMINANCE).SetInternalName("glowstone");
             Portal = new BlockInfo(90, "Portal").SetOpacity(0).SetLuminance(11).SetState(BlockState.NONSOLID);
-            JackOLantern = new BlockInfo(91, "Jack-O-Lantern").SetLuminance(MAX_LUMINANCE);
+            JackOLantern = new BlockInfo(91, "Jack-O-Lantern").SetLuminance(MAX_LUMINANCE).SetInternalName("lit_pumpkin");
             CakeBlock = new BlockInfo(92, "Cake Block").SetOpacity(0);
-            RedstoneRepeater = new BlockInfo(93, "Redstone Repeater (Off)").SetOpacity(0).SetTick(10);
-            RedstoneRepeaterOn = new BlockInfo(94, "Redstone Repeater (On)").SetOpacity(0).SetLuminance(7).SetTick(10);
+            RedstoneRepeater = new BlockInfo(93, "Redstone Repeater (Off)").SetOpacity(0).SetTick(10).SetInternalName("unpowered_repeater");
+            RedstoneRepeaterOn = new BlockInfo(94, "Redstone Repeater (On)").SetOpacity(0).SetLuminance(7).SetTick(10).SetInternalName("powered_repeater");
             LockedChest = (BlockInfoEx)new BlockInfoEx(95, "Locked Chest").SetLuminance(MAX_LUMINANCE).SetTick(10);
             StainedGlass = new BlockInfo(95, "Stained Glass").SetOpacity(0);
             Trapdoor = new BlockInfo(96, "Trapdoor").SetOpacity(0);
             SilverfishStone = new BlockInfo(97, "Stone with Silverfish");
-            StoneBrick = new BlockInfo(98, "Stone Brick");
-            HugeRedMushroom = new BlockInfo(99, "Huge Red Mushroom");
-            HugeBrownMushroom = new BlockInfo(100, "Huge Brown Mushroom");
+            StoneBrick = new BlockInfo(98, "Stone Brick").SetInternalName("stonebrick");
+            HugeRedMushroom = new BlockInfo(99, "Huge Red Mushroom").SetInternalName("red_mushroom_block");
+            HugeBrownMushroom = new BlockInfo(100, "Huge Brown Mushroom").SetInternalName("brown_mushroom_block");
             IronBars = new BlockInfo(101, "Iron Bars").SetOpacity(0);
             GlassPane = new BlockInfo(102, "Glass Pane").SetOpacity(0);
-            Melon = new BlockInfo(103, "Melon");
+            Melon = new BlockInfo(103, "Melon").SetInternalName("melon_block");
             PumpkinStem = new BlockInfo(104, "Pumpkin Stem").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10);
             MelonStem = new BlockInfo(105, "Melon Stem").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10);
-            Vines = new BlockInfo(106, "Vines").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10);
+            Vines = new BlockInfo(106, "Vines").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10).SetInternalName("vine");
             FenceGate = new BlockInfo(107, "Fence Gate").SetOpacity(0);
             BrickStairs = new BlockInfo(108, "Brick Stairs").SetOpacity(0);
             StoneBrickStairs = new BlockInfo(109, "Stone Brick Stairs").SetOpacity(0);
             Mycelium = new BlockInfo(110, "Mycelium").SetTick(10);
-            LillyPad = new BlockInfo(111, "Lilly Pad").SetOpacity(0).SetState(BlockState.NONSOLID);
+            LillyPad = new BlockInfo(111, "Lilly Pad").SetOpacity(0).SetState(BlockState.NONSOLID).SetInternalName("waterlily");
             NetherBrick = new BlockInfo(112, "Nether Brick");
             NetherBrickFence = new BlockInfo(113, "Nether Brick Fence").SetOpacity(0);
             NetherBrickStairs = new BlockInfo(114, "Nether Brick Stairs").SetOpacity(0);
             NetherWart = new BlockInfo(115, "Nether Wart").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10);
-            EnchantmentTable = (BlockInfoEx)new BlockInfoEx(116, "Enchantment Table").SetOpacity(0);
+            EnchantmentTable = (BlockInfoEx)new BlockInfoEx(116, "Enchantment Table").SetOpacity(0).SetInternalName("enchanting_table");
             BrewingStand = (BlockInfoEx)new BlockInfoEx(117, "Brewing Stand").SetOpacity(0);
             Cauldron = new BlockInfo(118, "Cauldron").SetOpacity(0);
             EndPortal = (BlockInfoEx)new BlockInfoEx(119, "End Portal").SetOpacity(0).SetLuminance(MAX_LUMINANCE).SetState(BlockState.NONSOLID);
             EndPortalFrame = new BlockInfo(120, "End Portal Frame").SetLuminance(MAX_LUMINANCE);
             EndStone = new BlockInfo(121, "End Stone");
             DragonEgg = new BlockInfo(122, "Dragon Egg").SetOpacity(0).SetLuminance(1).SetTick(3);
-            RedstoneLampOff = new BlockInfo(123, "Redstone Lamp (Off)").SetTick(2);
-            RedstoneLampOn = new BlockInfo(124, "Redstone Lamp (On)").SetLuminance(15).SetTick(2);
-            DoubleWoodSlab = new BlockInfo(125, "Double Wood Slab");
-            WoodSlab = new BlockInfo(126, "Wood Slab");
+            RedstoneLampOff = new BlockInfo(123, "Redstone Lamp (Off)").SetTick(2).SetInternalName("redstone_lamp");
+            RedstoneLampOn = new BlockInfo(124, "Redstone Lamp (On)").SetLuminance(15).SetTick(2).SetInternalName("lit_redstone_lamp");
+            DoubleWoodSlab = new BlockInfo(125, "Double Wood Slab").SetInternalName("double_wooden_slab");
+            WoodSlab = new BlockInfo(126, "Wood Slab").SetInternalName("wooden_slab");
             CocoaPlant = new BlockInfo(127, "Cocoa Plant").SetLuminance(2).SetOpacity(0);
             SandstoneStairs = new BlockInfo(128, "Sandstone Stairs").SetOpacity(0);
             EmeraldOre = new BlockInfo(129, "Emerald Ore");
@@ -879,37 +902,37 @@ namespace Substrate
             TripwireHook = new BlockInfo(131, "Tripwire Hook").SetOpacity(0).SetState(BlockState.NONSOLID);
             Tripwire = new BlockInfo(132, "Tripwire").SetOpacity(0).SetState(BlockState.NONSOLID);
             EmeraldBlock = new BlockInfo(133, "Emerald Block");
-            SpruceWoodStairs = new BlockInfo(134, "Sprice Wood Stairs").SetOpacity(0);
-            BirchWoodStairs = new BlockInfo(135, "Birch Wood Stairs").SetOpacity(0);
-            JungleWoodStairs = new BlockInfo(136, "Jungle Wood Stairs").SetOpacity(0);
+            SpruceWoodStairs = new BlockInfo(134, "Sprice Wood Stairs").SetOpacity(0).SetInternalName("spruce_stairs");
+            BirchWoodStairs = new BlockInfo(135, "Birch Wood Stairs").SetOpacity(0).SetInternalName("birch_stairs");
+            JungleWoodStairs = new BlockInfo(136, "Jungle Wood Stairs").SetOpacity(0).SetInternalName("jungle_stairs");
             CommandBlock = (BlockInfoEx)new BlockInfoEx(137, "Command Block");
-            BeaconBlock = (BlockInfoEx)new BlockInfoEx(138, "Beacon Block").SetOpacity(0).SetLuminance(MAX_LUMINANCE);
+            BeaconBlock = (BlockInfoEx)new BlockInfoEx(138, "Beacon Block").SetOpacity(0).SetLuminance(MAX_LUMINANCE).SetInternalName("beacon");
             CobblestoneWall = new BlockInfo(139, "Cobblestone Wall").SetOpacity(0);
             FlowerPot = new BlockInfo(140, "Flower Pot").SetOpacity(0);
             Carrots = new BlockInfo(141, "Carrots").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10);
             Potatoes = new BlockInfo(142, "Potatoes").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10);
             WoodButton = new BlockInfo(143, "Wooden Button").SetOpacity(0).SetState(BlockState.NONSOLID);
-            Heads = new BlockInfo(144, "Heads").SetOpacity(0);
+            Heads = new BlockInfo(144, "Heads").SetOpacity(0).SetInternalName("skull");
             Anvil = new BlockInfo(145, "Anvil").SetOpacity(0);
             TrappedChest = (BlockInfoEx)new BlockInfoEx(146, "Trapped Chest").SetOpacity(0).SetTick(10);
-            WeightedPressurePlateLight = new BlockInfo(147, "Weighted Pressure Plate (Light)").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(20);
-            WeightedPressurePlateHeavy = new BlockInfo(148, "Weighted Pressure Plate (Heavy)").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(20);
-            RedstoneComparatorInactive = new BlockInfo(149, "Redstone Comparator (Inactive)").SetOpacity(0).SetTick(10);
-            RedstoneComparatorActive = new BlockInfo(150, "Redstone Comparator (Active)").SetOpacity(0).SetLuminance(9).SetTick(10);
-            DaylightSensor = new BlockInfo(151, "Daylight Sensor").SetOpacity(0).SetTick(10);
-            RedstoneBlock = new BlockInfo(152, "Block of Redstone").SetTick(10);
-            NetherQuartzOre = new BlockInfo(153, "Neither Quartz Ore");
+            WeightedPressurePlateLight = new BlockInfo(147, "Weighted Pressure Plate (Light)").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(20).SetInternalName("light_weighted_pressure_plate");
+            WeightedPressurePlateHeavy = new BlockInfo(148, "Weighted Pressure Plate (Heavy)").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(20).SetInternalName("heavy_weighted_pressure_plate");
+            RedstoneComparatorInactive = new BlockInfo(149, "Redstone Comparator (Inactive)").SetOpacity(0).SetTick(10).SetInternalName("unpowered_comparator");
+            RedstoneComparatorActive = new BlockInfo(150, "Redstone Comparator (Active)").SetOpacity(0).SetLuminance(9).SetTick(10).SetInternalName("comparator");
+            DaylightSensor = new BlockInfo(151, "Daylight Sensor").SetOpacity(0).SetTick(10).SetInternalName("daylight_detector");
+            RedstoneBlock = new BlockInfo(152, "Block of Redstone").SetTick(10).SetInternalName("redstone_block");
+            NetherQuartzOre = new BlockInfo(153, "Nether Quartz Ore").SetInternalName("quartz_ore");
             Hopper = (BlockInfoEx)new BlockInfoEx(154, "Hopper").SetOpacity(0).SetTick(10);
-            QuartzBlock = new BlockInfo(155, "Block of Quartz");
+            QuartzBlock = new BlockInfo(155, "Block of Quartz").SetInternalName("quartz_block");
             QuartzStairs = new BlockInfo(156, "Quartz Stairs").SetOpacity(0);
             ActivatorRail = new BlockInfo(157, "Activator Rail").SetOpacity(0).SetState(BlockState.NONSOLID).SetTick(10);
             Dropper = (BlockInfoEx)new BlockInfoEx(158, "Dropper").SetTick(10);
-            StainedClay = new BlockInfo(159, "Stained Clay");
+            StainedClay = new BlockInfo(159, "Stained Clay").SetInternalName("stained_hardened_clay");
             StainedGlassPane = new BlockInfo(160, "Stained Glass Pane").SetOpacity(0);
             HayBlock = new BlockInfo(170, "Hay Block");
             Carpet = new BlockInfo(171, "Carpet").SetOpacity(0);
             HardenedClay = new BlockInfo(172, "Hardened Clay");
-            CoalBlock = new BlockInfo(173, "Block of Coal");
+            CoalBlock = new BlockInfo(173, "Block of Coal").SetInternalName("coal_block");
 
             for (int i = 0; i < MAX_BLOCKS; i++) {
                 if (_blockTable[i] == null) {

--- a/SubstrateCS/Source/Item.cs
+++ b/SubstrateCS/Source/Item.cs
@@ -12,7 +12,7 @@ namespace Substrate
     {
         private static readonly SchemaNodeCompound _schema = new SchemaNodeCompound("")
         {
-            new SchemaNodeScaler("id", TagType.TAG_SHORT),
+            new SchemaNodeScaler("id", TagType.TAG_SHORT, SchemaOptions.CAN_BE_STRING),
             new SchemaNodeScaler("Damage", TagType.TAG_SHORT),
             new SchemaNodeScaler("Count", TagType.TAG_BYTE),
             new SchemaNodeCompound("tag", new SchemaNodeCompound("") {
@@ -149,7 +149,32 @@ namespace Substrate
 
             _enchantments.Clear();
 
-            _id = ctree["id"].ToTagShort();
+            _id = 0;
+            if (ctree["id"] is TagNodeString)
+            {
+              TagNodeString str = ctree["id"].ToTagString();
+              ItemInfo info = ItemInfo.GetItemInfoByInternalName(str);
+              if (info != null)
+              {
+                _id = (short)info.ID;
+              }
+              else 
+              {
+                BlockInfo blockInfo = BlockInfo.GetBlockInfoByInternalName(str);
+                if (blockInfo != null)
+                {
+                  _id = (short)blockInfo.ID;
+                }
+                else
+                {
+                  throw new Exception("Item not found!");
+                }
+              }
+            }
+            else
+            {
+              _id = ctree["id"].ToTagShort();
+            }
             _count = ctree["Count"].ToTagByte();
             _damage = ctree["Damage"].ToTagShort();
 

--- a/SubstrateCS/Source/ItemInfo.cs
+++ b/SubstrateCS/Source/ItemInfo.cs
@@ -230,6 +230,7 @@ namespace Substrate
 
         private int _id = 0;
         private string _name = "";
+        private string _internal_name = "";
         private int _stack = 1;
 
         private static readonly CacheTableDict<ItemInfo> _itemTableCache;
@@ -239,7 +240,19 @@ namespace Substrate
         /// </summary>
         public static ICacheTable<ItemInfo> ItemTable
         {
-            get { return _itemTableCache; }
+          get { return _itemTableCache; }
+        }
+
+        public static ItemInfo GetItemInfoByInternalName( string internalName )
+        {
+          foreach(KeyValuePair<int,ItemInfo> kvp in _itemTable)
+          {
+            if (kvp.Value._internal_name == internalName)
+            {
+              return kvp.Value;
+            }
+          }
+          return null;
         }
 
         /// <summary>
@@ -285,7 +298,14 @@ namespace Substrate
         {
             _id = id;
             _name = name;
+            _internal_name = "minecraft:" + name.ToLower().Replace(' ','_');
             _itemTable[_id] = this;
+        }
+
+        public ItemInfo SetInternalName (string name)
+        {
+            _internal_name = "minecraft:" + name;
+            return this;
         }
 
         /// <summary>
@@ -511,10 +531,10 @@ namespace Substrate
             Stick = new ItemInfo(280, "Stick").SetStackSize(64);
             Bowl = new ItemInfo(281, "Bowl").SetStackSize(64);
             MushroomSoup = new ItemInfo(282, "Mushroom Soup");
-            GoldSword = new ItemInfo(283, "Gold Sword");
-            GoldShovel = new ItemInfo(284, "Gold Shovel");
-            GoldPickaxe = new ItemInfo(285, "Gold Pickaxe");
-            GoldAxe = new ItemInfo(286, "Gold Axe");
+            GoldSword = new ItemInfo(283, "Gold Sword").SetInternalName("golden_sword");
+            GoldShovel = new ItemInfo(284, "Gold Shovel").SetInternalName("golden_shovel");
+            GoldPickaxe = new ItemInfo(285, "Gold Pickaxe").SetInternalName("golden_pickaxe");
+            GoldAxe = new ItemInfo(286, "Gold Axe").SetInternalName("golden_axe");
             String = new ItemInfo(287, "String").SetStackSize(64);
             Feather = new ItemInfo(288, "Feather").SetStackSize(64);
             Gunpowder = new ItemInfo(289, "Gunpowder").SetStackSize(64);
@@ -523,17 +543,17 @@ namespace Substrate
             IronHoe = new ItemInfo(292, "Iron Hoe");
             DiamondHoe = new ItemInfo(293, "Diamond Hoe");
             GoldHoe = new ItemInfo(294, "Gold Hoe");
-            Seeds = new ItemInfo(295, "Seeds").SetStackSize(64);
+            Seeds = new ItemInfo(295, "Seeds").SetStackSize(64).SetInternalName("wheat_seeds");
             Wheat = new ItemInfo(296, "Wheat").SetStackSize(64);
             Bread = new ItemInfo(297, "Bread").SetStackSize(64);
-            LeatherCap = new ItemInfo(298, "Leather Cap");
-            LeatherTunic = new ItemInfo(299, "Leather Tunic");
-            LeatherPants = new ItemInfo(300, "Leather Pants");
+            LeatherCap = new ItemInfo(298, "Leather Cap").SetInternalName("leather_helmet");
+            LeatherTunic = new ItemInfo(299, "Leather Tunic").SetInternalName("leather_chestplate");
+            LeatherPants = new ItemInfo(300, "Leather Pants").SetInternalName("leather_leggings");
             LeatherBoots = new ItemInfo(301, "Leather Boots");
-            ChainHelmet = new ItemInfo(302, "Chain Helmet");
-            ChainChestplate = new ItemInfo(303, "Chain Chestplate");
-            ChainLeggings = new ItemInfo(304, "Chain Leggings");
-            ChainBoots = new ItemInfo(305, "Chain Boots");
+            ChainHelmet = new ItemInfo(302, "Chain Helmet").SetInternalName("chainmail_helmet");
+            ChainChestplate = new ItemInfo(303, "Chain Chestplate").SetInternalName("chainmail_chestplate");
+            ChainLeggings = new ItemInfo(304, "Chain Leggings").SetInternalName("chainmail_leggings");
+            ChainBoots = new ItemInfo(305, "Chain Boots").SetInternalName("chainmail_boots");
             IronHelmet = new ItemInfo(306, "Iron Helmet");
             IronChestplate = new ItemInfo(307, "Iron Chestplate");
             IronLeggings = new ItemInfo(308, "Iron Leggings");
@@ -542,12 +562,12 @@ namespace Substrate
             DiamondChestplate = new ItemInfo(311, "Diamond Chestplate");
             DiamondLeggings = new ItemInfo(312, "Diamond Leggings");
             DiamondBoots = new ItemInfo(313, "Diamond Boots");
-            GoldHelmet = new ItemInfo(314, "Gold Helmet");
-            GoldChestplate = new ItemInfo(315, "Gold Chestplate");
-            GoldLeggings = new ItemInfo(316, "Gold Leggings");
-            GoldBoots = new ItemInfo(317, "Gold Boots");
+            GoldHelmet = new ItemInfo(314, "Gold Helmet").SetInternalName("golden_helmet");
+            GoldChestplate = new ItemInfo(315, "Gold Chestplate").SetInternalName("golden_chestplate");
+            GoldLeggings = new ItemInfo(316, "Gold Leggings").SetInternalName("golden_leggings");
+            GoldBoots = new ItemInfo(317, "Gold Boots").SetInternalName("golden_boots");
             Flint = new ItemInfo(318, "Flint").SetStackSize(64);
-            RawPorkchop = new ItemInfo(319, "Raw Porkchop").SetStackSize(64);
+            RawPorkchop = new ItemInfo(319, "Raw Porkchop").SetStackSize(64).SetInternalName("porkchop");
             CookedPorkchop = new ItemInfo(320, "Cooked Porkchop").SetStackSize(64);
             Painting = new ItemInfo(321, "Painting").SetStackSize(64);
             GoldenApple = new ItemInfo(322, "Golden Apple").SetStackSize(64);
@@ -559,41 +579,41 @@ namespace Substrate
             Minecart = new ItemInfo(328, "Minecart");
             Saddle = new ItemInfo(329, "Saddle");
             IronDoor = new ItemInfo(330, "Iron Door");
-            RedstoneDust = new ItemInfo(331, "Redstone Dust").SetStackSize(64);
+            RedstoneDust = new ItemInfo(331, "Redstone Dust").SetStackSize(64).SetInternalName("redstone");
             Snowball = new ItemInfo(332, "Snowball").SetStackSize(16);
             Boat = new ItemInfo(333, "Boat");
             Leather = new ItemInfo(334, "Leather").SetStackSize(64);
-            Milk = new ItemInfo(335, "Milk");
-            ClayBrick = new ItemInfo(336, "Clay Brick").SetStackSize(64);
-            Clay = new ItemInfo(337, "Clay").SetStackSize(64);
-            SugarCane = new ItemInfo(338, "Sugar Cane").SetStackSize(64);
+            Milk = new ItemInfo(335, "Milk").SetInternalName("milk_bucket");
+            ClayBrick = new ItemInfo(336, "Clay Brick").SetStackSize(64).SetInternalName("brick");
+            Clay = new ItemInfo(337, "Clay").SetStackSize(64).SetInternalName("clay_ball");
+            SugarCane = new ItemInfo(338, "Sugar Cane").SetStackSize(64).SetInternalName("reeds");
             Paper = new ItemInfo(339, "Paper").SetStackSize(64);
             Book = new ItemInfo(340, "Book").SetStackSize(64);
-            Slimeball = new ItemInfo(341, "Slimeball").SetStackSize(64);
-            StorageMinecart = new ItemInfo(342, "Storage Miencart");
+            Slimeball = new ItemInfo(341, "Slimeball").SetStackSize(64).SetInternalName("slime_ball");
+            StorageMinecart = new ItemInfo(342, "Storage Minecart").SetInternalName("chest_minecart");
             PoweredMinecart = new ItemInfo(343, "Powered Minecart");
             Egg = new ItemInfo(344, "Egg").SetStackSize(16);
             Compass = new ItemInfo(345, "Compass");
             FishingRod = new ItemInfo(346, "Fishing Rod");
             Clock = new ItemInfo(347, "Clock");
             GlowstoneDust = new ItemInfo(348, "Glowstone Dust").SetStackSize(64);
-            RawFish = new ItemInfo(349, "Raw Fish").SetStackSize(64);
+            RawFish = new ItemInfo(349, "Raw Fish").SetStackSize(64).SetInternalName("fish");
             CookedFish = new ItemInfo(350, "Cooked Fish").SetStackSize(64);
             Dye = new ItemInfo(351, "Dye").SetStackSize(64);
             Bone = new ItemInfo(352, "Bone").SetStackSize(64);
             Sugar = new ItemInfo(353, "Sugar").SetStackSize(64);
             Cake = new ItemInfo(354, "Cake");
             Bed = new ItemInfo(355, "Bed");
-            RedstoneRepeater = new ItemInfo(356, "Redstone Repeater").SetStackSize(64);
+            RedstoneRepeater = new ItemInfo(356, "Redstone Repeater").SetStackSize(64).SetInternalName("repeater");
             Cookie = new ItemInfo(357, "Cookie").SetStackSize(8);
-            Map = new ItemInfo(358, "Map");
+            Map = new ItemInfo(358, "Map").SetInternalName("filled_map");
             Shears = new ItemInfo(359, "Shears");
             MelonSlice = new ItemInfo(360, "Melon Slice").SetStackSize(64);
             PumpkinSeeds = new ItemInfo(361, "Pumpkin Seeds").SetStackSize(64);
             MelonSeeds = new ItemInfo(362, "Melon Seeds").SetStackSize(64);
-            RawBeef = new ItemInfo(363, "Raw Beef").SetStackSize(64);
-            Steak = new ItemInfo(364, "Steak").SetStackSize(64);
-            RawChicken = new ItemInfo(365, "Raw Chicken").SetStackSize(64);
+            RawBeef = new ItemInfo(363, "Raw Beef").SetStackSize(64).SetInternalName("beef");
+            Steak = new ItemInfo(364, "Steak").SetStackSize(64).SetInternalName("cooked_beef");
+            RawChicken = new ItemInfo(365, "Raw Chicken").SetStackSize(64).SetInternalName("chicken");
             CookedChicken = new ItemInfo(366, "Cooked Chicken").SetStackSize(64);
             RottenFlesh = new ItemInfo(367, "Rotten Flesh").SetStackSize(64);
             EnderPearl = new ItemInfo(368, "Ender Pearl").SetStackSize(64);
@@ -609,12 +629,12 @@ namespace Substrate
             MagmaCream = new ItemInfo(378, "Magma Cream").SetStackSize(64);
             BrewingStand = new ItemInfo(379, "Brewing Stand").SetStackSize(64);
             Cauldron = new ItemInfo(380, "Cauldron");
-            EyeOfEnder = new ItemInfo(381, "Eye of Ender").SetStackSize(64);
-            GlisteringMelon = new ItemInfo(382, "Glistering Melon").SetStackSize(64);
+            EyeOfEnder = new ItemInfo(381, "Eye of Ender").SetStackSize(64).SetInternalName("ender_eye");
+            GlisteringMelon = new ItemInfo(382, "Glistering Melon").SetStackSize(64).SetInternalName("speckled_melon");
             SpawnEgg = new ItemInfo(383, "Spawn Egg").SetStackSize(64);
-            BottleOEnchanting = new ItemInfo(384, "Bottle O' Enchanting").SetStackSize(64);
+            BottleOEnchanting = new ItemInfo(384, "Bottle O' Enchanting").SetStackSize(64).SetInternalName("experience_bottle");
             FireCharge = new ItemInfo(385, "Fire Charge").SetStackSize(64);
-            BookAndQuill = new ItemInfo(386, "Book and Quill");
+            BookAndQuill = new ItemInfo(386, "Book and Quill").SetInternalName("writable_book");
             WrittenBook = new ItemInfo(387, "Written Book");
             Emerald = new ItemInfo(388, "Emerald").SetStackSize(64);
             ItemFrame = new ItemInfo(389, "Item Frame").SetStackSize(64);
@@ -625,34 +645,34 @@ namespace Substrate
             PoisonPotato = new ItemInfo(394, "Poisonous Potato").SetStackSize(64);
             EmptyMap = new ItemInfo(395, "Empty Map").SetStackSize(64);
             GoldenCarrot = new ItemInfo(396, "Golden Carrot").SetStackSize(64);
-            MobHead = new ItemInfo(397, "Mob Head").SetStackSize(64);
+            MobHead = new ItemInfo(397, "Mob Head").SetStackSize(64).SetInternalName("skull");
             CarrotOnStick = new ItemInfo(398, "Carrot on a Stick");
             NetherStar = new ItemInfo(399, "Nether Star").SetStackSize(64);
             PumpkinPie = new ItemInfo(400, "Pumpkin Pie").SetStackSize(64);
-            FireworkRocket = new ItemInfo(401, "Firework Rocket");
-            FireworkStar = new ItemInfo(402, "Firework Star").SetStackSize(64);
+            FireworkRocket = new ItemInfo(401, "Firework Rocket").SetInternalName("fireworks");
+            FireworkStar = new ItemInfo(402, "Firework Star").SetStackSize(64).SetInternalName("firework_charge");
             EnchantedBook = new ItemInfo(403, "Enchanted Book");
-            RedstoneComparator = new ItemInfo(404, "Redstone Comparator").SetStackSize(64);
-            NetherBrick = new ItemInfo(405, "Nether Brick").SetStackSize(64);
-            NetherQuartz = new ItemInfo(406, "Nether Quartz").SetStackSize(64);
+            RedstoneComparator = new ItemInfo(404, "Redstone Comparator").SetStackSize(64).SetInternalName("comparator");
+            NetherBrick = new ItemInfo(405, "Nether Brick").SetStackSize(64).SetInternalName("netherbrick");
+            NetherQuartz = new ItemInfo(406, "Nether Quartz").SetStackSize(64).SetInternalName("quartz");
             TntMinecart = new ItemInfo(407, "Minecart with TNT");
             HopperMinecart = new ItemInfo(408, "Minecart with Hopper");
             IronHorseArmor = new ItemInfo(417, "Iron Horse Armor");
-            GoldHorseArmor = new ItemInfo(418, "Gold Horse Armor");
+            GoldHorseArmor = new ItemInfo(418, "Gold Horse Armor").SetInternalName("golden_horse_armor");
             DiamondHorseArmor = new ItemInfo(419, "Diamond Horse Armor");
             Lead = new ItemInfo(420, "Lead").SetStackSize(64);
             NameTag = new ItemInfo(421, "Name Tag").SetStackSize(64);
-            MusicDisc13 = new ItemInfo(2256, "13 Disc");
-            MusicDiscCat = new ItemInfo(2257, "Cat Disc");
-            MusicDiscBlocks = new ItemInfo(2258, "Blocks Disc");
-            MusicDiscChirp = new ItemInfo(2259, "Chirp Disc");
-            MusicDiscFar = new ItemInfo(2260, "Far Disc");
-            MusicDiscMall = new ItemInfo(2261, "Mall Disc");
-            MusicDiscMellohi = new ItemInfo(2262, "Mellohi Disc");
-            MusicDiscStal = new ItemInfo(2263, "Stal Disc");
-            MusicDiscStrad = new ItemInfo(2264, "Strad Disc");
-            MusicDiscWard = new ItemInfo(2265, "Ward Disc");
-            MusicDisc11 = new ItemInfo(2266, "11 Disc");
+            MusicDisc13 = new ItemInfo(2256, "13 Disc").SetInternalName("record_13");
+            MusicDiscCat = new ItemInfo(2257, "Cat Disc").SetInternalName("record_cat");
+            MusicDiscBlocks = new ItemInfo(2258, "Blocks Disc").SetInternalName("record_blocks");
+            MusicDiscChirp = new ItemInfo(2259, "Chirp Disc").SetInternalName("record_chirp");
+            MusicDiscFar = new ItemInfo(2260, "Far Disc").SetInternalName("record_far");
+            MusicDiscMall = new ItemInfo(2261, "Mall Disc").SetInternalName("record_mall");
+            MusicDiscMellohi = new ItemInfo(2262, "Mellohi Disc").SetInternalName("record_mellohi");
+            MusicDiscStal = new ItemInfo(2263, "Stal Disc").SetInternalName("record_stal");
+            MusicDiscStrad = new ItemInfo(2264, "Strad Disc").SetInternalName("record_strad");
+            MusicDiscWard = new ItemInfo(2265, "Ward Disc").SetInternalName("record_ward");
+            MusicDisc11 = new ItemInfo(2266, "11 Disc").SetInternalName("record_11");
         }
     }
 }

--- a/SubstrateCS/Source/Nbt/NbtVerifier.cs
+++ b/SubstrateCS/Source/Nbt/NbtVerifier.cs
@@ -194,6 +194,11 @@ namespace Substrate.Nbt
         private bool VerifyScaler (TagNode tag, SchemaNodeScaler schema)
         {
             if (!tag.IsCastableTo(schema.Type)) {
+                if (tag is TagNodeString && (schema.Options & SchemaOptions.CAN_BE_STRING) == SchemaOptions.CAN_BE_STRING)
+                {
+                    return true;
+                }
+
                 if (!OnInvalidTagType(new TagEventArgs(schema.Name, tag))) {
                     return false;
                 }

--- a/SubstrateCS/Source/Nbt/SchemaOptions.cs
+++ b/SubstrateCS/Source/Nbt/SchemaOptions.cs
@@ -17,5 +17,10 @@ namespace Substrate.Nbt
         /// If a <see cref="TagNode"/> cannot be found for a <see cref="SchemaNode"/> marked with this option, a sensible default <see cref="TagNode"/> will be created and inserted into the tree.
         /// </summary>
         CREATE_ON_MISSING = 0x2,
+
+        /// <summary>
+        /// This <see cref="SchemaNode"/> is allowed to be either its normal type or <see cref="TagNodeString"/> (1.8 changes)
+        /// </summary>
+        CAN_BE_STRING = 0x4,
     }
 }

--- a/SubstrateCS/Source/TileTick.cs
+++ b/SubstrateCS/Source/TileTick.cs
@@ -13,7 +13,7 @@ namespace Substrate
     {
         private static readonly SchemaNodeCompound _schema = new SchemaNodeCompound("")
         {
-            new SchemaNodeScaler("i", TagType.TAG_INT),
+            new SchemaNodeScaler("i", TagType.TAG_INT, SchemaOptions.CAN_BE_STRING),
             new SchemaNodeScaler("t", TagType.TAG_INT),
             new SchemaNodeScaler("x", TagType.TAG_INT),
             new SchemaNodeScaler("y", TagType.TAG_INT),
@@ -164,7 +164,32 @@ namespace Substrate
                 return null;
             }
 
-            _blockId = ctree["i"].ToTagInt();
+            _blockId = 0;
+            if (ctree["i"] is TagNodeString)
+            {
+              TagNodeString str = ctree["i"].ToTagString();
+              ItemInfo info = ItemInfo.GetItemInfoByInternalName(str);
+              if (info != null)
+              {
+                _blockId = (short)info.ID;
+              }
+              else
+              {
+                BlockInfo blockInfo = BlockInfo.GetBlockInfoByInternalName(str);
+                if (blockInfo != null)
+                {
+                  _blockId = (short)blockInfo.ID;
+                }
+                else
+                {
+                  throw new Exception("Item not found!");
+                }
+              }
+            }
+            else
+            {
+              _blockId = ctree["i"].ToTagInt();
+            }
             _ticks = ctree["t"].ToTagInt();
             _x = ctree["x"].ToTagInt();
             _y = ctree["y"].ToTagInt();


### PR DESCRIPTION
Should work for the most part, I tried to add all the itemIDs that didn't match the naming convention - didn't add any of the 1.8.x blocks though. The Get* functions could be changed into a string-based cached dictionary. 