### PR TITLE
Fix invalid JSON when regional options not English

### DIFF
--- a/SubstrateCS/Source/Nbt/JSONSerializer.cs
+++ b/SubstrateCS/Source/Nbt/JSONSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using Substrate.Core;
 
@@ -196,11 +197,11 @@ namespace Substrate.Nbt
                     break;
 
                 case TagType.TAG_FLOAT:
-                    str.Append(tag.ToTagFloat().Data);
+                    str.Append(tag.ToTagFloat().Data.ToString(CultureInfo.InvariantCulture)));
                     break;
 
                 case TagType.TAG_DOUBLE:
-                    str.Append(tag.ToTagDouble().Data);
+                    str.Append(tag.ToTagDouble().Data.ToString(CultureInfo.InvariantCulture)));
                     break;
 
                 case TagType.TAG_BYTE_ARRAY:


### PR DESCRIPTION
Most European countries use [comma as the decimal separator](https://en.wikipedia.org/wiki/Decimal_separator#/media/File:DecimalSeparator.svg) (i.e. an amount of one and a quarter is written as 0,25). This emits invalid JSON data. This fixes this.